### PR TITLE
39 challenge cards status

### DIFF
--- a/client/lib/challenges_list.dart
+++ b/client/lib/challenges_list.dart
@@ -1,41 +1,47 @@
 import 'package:flutter/material.dart';
 import 'package:trailquest/widgets/challenge_cards.dart';
 
-const List<ChallengeCard> challenges = <ChallengeCard>[
+List<ChallengeCard> challenges = <ChallengeCard>[
   ChallengeCard(
     name: '10 statues in Uppsala', 
     type: 'Checkpoints', 
     description: Text('Find these 10 statues'), 
-    timeLimit: false
+    timeLimit: false,
+    status: 0,
   ),
   ChallengeCard(
     name: 'Questions about birds', 
     type: 'Quiz', 
     description: Text('Answer questions about birds'), 
-    timeLimit: true
+    timeLimit: true,
+    status: 2
   ),
   ChallengeCard(
     name: 'Cool large rocks', 
     type: 'Checkpoints', 
     description: Text('Visit cool large rocks in Uppsala'), 
-    timeLimit: true
+    timeLimit: true,
+    status: 1,
   ),
   ChallengeCard(
     name: 'Orienteering in Luthagen', 
     type: 'Orienteering', 
     description: Text('Gather control points in Luthagen'), 
-    timeLimit: true
+    timeLimit: true,
+    status: 1,
   ),
   ChallengeCard(
     name: 'Questions about plants', 
     type: 'Quiz', 
     description: Text('Answer questions about plants'), 
-    timeLimit: true
+    timeLimit: true,
+    status: 2,
   ),
   ChallengeCard(
     name: 'Important buildings', 
     type: 'Quiz', 
-    description: Text('Answer questions about importnat b'), 
-    timeLimit: true
+    description: Text('Answer questions about importnat buildings'), 
+    timeLimit: true,
+    status: 0
   ),
 ];

--- a/client/lib/challenges_list.dart
+++ b/client/lib/challenges_list.dart
@@ -6,42 +6,42 @@ List<ChallengeCard> challenges = <ChallengeCard>[
     name: '10 statues in Uppsala', 
     type: 'Checkpoints', 
     description: Text('Find these 10 statues'), 
-    timeLimit: false,
+    //timeLimit: true,
     status: 0,
   ),
   ChallengeCard(
     name: 'Questions about birds', 
     type: 'Quiz', 
     description: Text('Answer questions about birds'), 
-    timeLimit: true,
+    //timeLimit: true,
     status: 2
   ),
   ChallengeCard(
     name: 'Cool large rocks', 
     type: 'Checkpoints', 
     description: Text('Visit cool large rocks in Uppsala'), 
-    timeLimit: true,
+    //timeLimit: false,
     status: 1,
   ),
   ChallengeCard(
     name: 'Orienteering in Luthagen', 
     type: 'Orienteering', 
     description: Text('Gather control points in Luthagen'), 
-    timeLimit: true,
+    //timeLimit: false,
     status: 1,
   ),
   ChallengeCard(
     name: 'Questions about plants', 
     type: 'Quiz', 
     description: Text('Answer questions about plants'), 
-    timeLimit: true,
+    //timeLimit: true,
     status: 2,
   ),
   ChallengeCard(
     name: 'Important buildings', 
     type: 'Quiz', 
     description: Text('Answer questions about importnat buildings'), 
-    timeLimit: true,
+    //timeLimit: false,
     status: 0
   ),
 ];

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -18,7 +18,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized(); // Required by FlutterConfig
   await FlutterConfig.loadEnvVariables();
   var googleMapsApiKey = FlutterConfig.get('GOOGLE_MAPS_API_KEY');
-  channel = WebSocketChannel.connect(Uri.parse("ws://localhost:3000"));
+  channel = WebSocketChannel.connect(Uri.parse("ws://trocader.duckdns.org:3000"));
   runApp(const MainApp());
 }
 

--- a/client/lib/pages/challenge_page.dart
+++ b/client/lib/pages/challenge_page.dart
@@ -92,6 +92,7 @@ class _ChallengeState extends State<ChallengePage> {
                           for (int i = 0; i < _selectedStatus.length; i++) {
                             _selectedStatus[i] = i == index;
                           }
+                           //_selectedStatus[index] = !_selectedStatus[index];
                         });
                       },
                       borderRadius: const BorderRadius.all(Radius.circular(8)),
@@ -177,6 +178,14 @@ Widget scrollChallenges(BuildContext context) {
 // Filters the list of challenges depending on what filters are true (active) in the filter buttons
 List<ChallengeCard> filterChallenges(BuildContext context, List<ChallengeCard> list) {
   List<String?> activeTypes = [];
+  int activeStatus = 3; //defalut is 'all'
+
+  for(int i = 0; i < _selectedStatus.length; i++) {
+    if(_selectedStatus[i]) {
+      activeStatus = i;
+    }    
+  }
+  
   for(int i = 0; i < _selectedType.length; i++) {
     if(_selectedType[i]) { 
       String? type = typeChallenge[i].data;
@@ -184,17 +193,23 @@ List<ChallengeCard> filterChallenges(BuildContext context, List<ChallengeCard> l
     }
   }
 
-  if(activeTypes.length == 0) {
+  if(activeTypes.length == 0 && activeStatus > 2) {
     return list;
   } else {
     List<ChallengeCard> filteredChallenges = [];
+
     for(int i = 0; i < list.length; i++) {
-      for(int j = 0; j < activeTypes.length; j++) {
-        if(activeTypes[j] == list[i].type) {
+      if(list[i].status == activeStatus) {
         filteredChallenges.add(list[i]);
-        }
+      } else {
+          for(int j = 0; j < activeTypes.length; j++) {
+            if(activeTypes[j] == list[i].type) {
+              filteredChallenges.add(list[i]);
+            }
+          }
       }
     }
+
     if(filteredChallenges.length == 0) {
       return list;
     } else {

--- a/client/lib/pages/challenge_page.dart
+++ b/client/lib/pages/challenge_page.dart
@@ -12,10 +12,11 @@ import 'package:trailquest/widgets/challenge_cards.dart';
 const List<Widget> statusChallenge = <Widget>[
   Text('Not started'),
   Text('Ongoing'),
+  Text('Done'),
   Text('All')
 ];
 
-final List<bool> _selectedStatus = <bool>[false, false, true];
+final List<bool> _selectedStatus = <bool>[false, false, false, true];
 
 
 //Filters for the type of challenge
@@ -49,7 +50,7 @@ class _ChallengeState extends State<ChallengePage> {
         ),
         body: Scaffold(
           appBar: PreferredSize(
-            preferredSize: Size.fromHeight(130),
+            preferredSize: Size.fromHeight(150),
             child: AppBar(
               backgroundColor: Colors.green.shade600,
               actions: [
@@ -100,7 +101,7 @@ class _ChallengeState extends State<ChallengePage> {
                       color: Colors.white,
                       constraints: const BoxConstraints(
                         minHeight: 30.0,
-                        minWidth: 80.0
+                        minWidth: 100.0
                       ),
                       isSelected: _selectedStatus,
                       children: statusChallenge,

--- a/client/lib/pages/challenge_page.dart
+++ b/client/lib/pages/challenge_page.dart
@@ -195,18 +195,28 @@ List<ChallengeCard> filterChallenges(BuildContext context, List<ChallengeCard> l
 
   if(activeTypes.length == 0 && activeStatus > 2) {
     return list;
+
   } else {
     List<ChallengeCard> filteredChallenges = [];
-
-    for(int i = 0; i < list.length; i++) {
-      if(list[i].status == activeStatus) {
-        filteredChallenges.add(list[i]);
-      } else {
+    if(activeTypes.length > 0 && activeStatus < 3) {
+      for(int i = 0; i < list.length; i++) {
+        for(int j = 0; j < activeTypes.length; j++) {
+            if(activeTypes[j] == list[i].type && list[i].status == activeStatus) {
+              filteredChallenges.add(list[i]);
+            }
+          }
+      }
+    } else {
+      for(int i = 0; i < list.length; i++) {
+        if(list[i].status == activeStatus) {
+          filteredChallenges.add(list[i]);
+        } else {
           for(int j = 0; j < activeTypes.length; j++) {
             if(activeTypes[j] == list[i].type) {
               filteredChallenges.add(list[i]);
             }
           }
+        }
       }
     }
 

--- a/client/lib/pages/challenge_page.dart
+++ b/client/lib/pages/challenge_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:trailquest/challenges_list.dart';
 import 'package:trailquest/widgets/challenge_cards.dart';
-import 'package:trailquest/widgets/filter_buttons.dart';
 
 /**
  * The page where all challenge cards are displayed

--- a/client/lib/pages/start_page.dart
+++ b/client/lib/pages/start_page.dart
@@ -100,7 +100,7 @@ List<ChallengeCard> filterOngoing(BuildContext context) {
       name: 'null', 
       type: 'null', 
       status: 1, 
-      timeLimit: false,
+      //timeLimit: false,
     ));
   }
   return ongoing;

--- a/client/lib/pages/start_page.dart
+++ b/client/lib/pages/start_page.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:trailquest/challenges_list.dart';
+import 'package:trailquest/widgets/challenge_cards.dart';
 
 Future<dynamic> _requestLocationPermission() async {
   if (await Permission.location.request().isGranted) {
@@ -11,6 +13,8 @@ Future<dynamic> _requestLocationPermission() async {
     return Future.error("Location services were denied");
   }
 }
+
+
 
 class StartPage extends StatefulWidget {
   const StartPage({super.key});
@@ -31,6 +35,8 @@ class _StartPageState extends State<StartPage> {
 
   @override
   Widget build(BuildContext context) {
+    List<ChallengeCard> ongoingChallenges = filterOngoing(context);
+
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: Scaffold(
@@ -44,8 +50,40 @@ class _StartPageState extends State<StartPage> {
             ),
           ),
         ),
-        body: Stack(
+        body: Scaffold(
+          appBar: PreferredSize(
+            preferredSize: Size.fromHeight(200),
+            child: AppBar(
+              flexibleSpace: ListView.separated(
+                shrinkWrap: true,
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.all(8),
+                itemCount: ongoingChallenges.length,
+                itemBuilder: (context, index) {
+                  return ongoingChallenges[index];
+                },
+                separatorBuilder: (_, __) => const Divider(),
+              ),)
+                //(
+                //mainAxisAlignment: MainAxisAlignment.center,
+                //children: [
+                  /*PreferredSize(
+                    preferredSize: Size.fromHeight(150),
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      padding: const EdgeInsets.all(8),
+                      itemCount: ongoingChallenges.length,
+                      itemBuilder: (context, index) {
+                        return ongoingChallenges[index];
+                      },
+                      separatorBuilder: (BuildContext context, int index) => const Divider(),
+                    ),
+                  ),*/
+                //]
+          ),
+          body: Stack(
           children: [
+            Text('map'),
             // FIXME: Broken for som reason
             // ListView(
             //   scrollDirection: Axis.horizontal,
@@ -70,7 +108,7 @@ class _StartPageState extends State<StartPage> {
             //     )
             //   ],
             // ),
-            GoogleMap(
+            /*GoogleMap(
               onMapCreated: (GoogleMapController controller) {
                 _controller.complete(controller);
               },
@@ -80,10 +118,30 @@ class _StartPageState extends State<StartPage> {
               initialCameraPosition: CameraPosition(
                   target: LatLng(59.83972677529924, 17.6465716818546),
                   zoom: 15),
-            ),
+            ),*/
           ],
         ),
       ),
+      )
     );
   }
+}
+
+List<ChallengeCard> filterOngoing(BuildContext context) {
+  List<ChallengeCard> ongoing = [];
+  for(int i = 0; i < challenges.length; i++) {
+    if(challenges[i].status == 1) {
+      ongoing.add(challenges[i]);
+    }
+  }
+  if(ongoing.length == 0) {
+    ongoing.add(ChallengeCard(
+      description: Text('null'), 
+      name: 'null', 
+      type: 'null', 
+      status: 1, 
+      timeLimit: false,
+    ));
+  }
+  return ongoing;
 }

--- a/client/lib/pages/start_page.dart
+++ b/client/lib/pages/start_page.dart
@@ -63,52 +63,12 @@ class _StartPageState extends State<StartPage> {
                   return ongoingChallenges[index];
                 },
                 separatorBuilder: (_, __) => const Divider(),
-              ),)
-                //(
-                //mainAxisAlignment: MainAxisAlignment.center,
-                //children: [
-                  /*PreferredSize(
-                    preferredSize: Size.fromHeight(150),
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      padding: const EdgeInsets.all(8),
-                      itemCount: ongoingChallenges.length,
-                      itemBuilder: (context, index) {
-                        return ongoingChallenges[index];
-                      },
-                      separatorBuilder: (BuildContext context, int index) => const Divider(),
-                    ),
-                  ),*/
-                //]
+              ),
+            )
           ),
           body: Stack(
           children: [
-            Text('map'),
-            // FIXME: Broken for som reason
-            // ListView(
-            //   scrollDirection: Axis.horizontal,
-            //   children: [
-            //     Card(
-            //       child: Placeholder(
-            //         fallbackHeight: 50,
-            //         fallbackWidth: 20,
-            //       ),
-            //     ),
-            //     Card(
-            //       child: Placeholder(
-            //         fallbackHeight: 50,
-            //         fallbackWidth: 20,
-            //       ),
-            //     ),
-            //     Card(
-            //       child: Placeholder(
-            //         fallbackHeight: 50,
-            //         fallbackWidth: 20,
-            //       ),
-            //     )
-            //   ],
-            // ),
-            /*GoogleMap(
+            GoogleMap(
               onMapCreated: (GoogleMapController controller) {
                 _controller.complete(controller);
               },
@@ -118,7 +78,7 @@ class _StartPageState extends State<StartPage> {
               initialCameraPosition: CameraPosition(
                   target: LatLng(59.83972677529924, 17.6465716818546),
                   zoom: 15),
-            ),*/
+            ),
           ],
         ),
       ),

--- a/client/lib/widgets/challenge_cards.dart
+++ b/client/lib/widgets/challenge_cards.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
@@ -13,13 +15,16 @@ class ChallengeCard extends StatefulWidget{
   final String name;
   final Text description;
   final bool timeLimit;
+  // 0 = not started, 1 = ongoing, 2 = done
+  int status;
 
-  const ChallengeCard({
+  ChallengeCard({
     super.key,
     required this.name,
     required this.type,
     required this.description,
-    required this.timeLimit
+    required this.timeLimit,
+    required this.status
   });
 
   @override
@@ -41,6 +46,7 @@ class _CardState extends State<ChallengeCard> {
         },
         child: Container(
           height: 150,
+          width: 380,
           color: const Color.fromARGB(255, 89, 164, 224),
           child: Padding(
             padding: EdgeInsets.only(left: 10),
@@ -103,6 +109,7 @@ class _CardState extends State<ChallengeCard> {
         },
         child: Container(
           height: 150,
+          width: 380,
           color: Color.fromARGB(255, 250, 159, 74),
           child: Padding(
             padding: EdgeInsets.only(left: 10),
@@ -165,6 +172,7 @@ class _CardState extends State<ChallengeCard> {
         },
         child: Container(
           height: 150,
+          width: 380,
           color: Color.fromARGB(255, 137, 70, 196),
           child: Padding(
             padding: EdgeInsets.only(left: 10),
@@ -220,6 +228,7 @@ class _CardState extends State<ChallengeCard> {
         onTap:() {},
         child: Container(
           height: 150,
+          width: 380,
           color: Color.fromARGB(255, 92, 95, 97),
         
           child: Padding(
@@ -231,7 +240,7 @@ class _CardState extends State<ChallengeCard> {
                   child: Padding(
                     padding: EdgeInsets.only(top: 5),
                     child: Text(
-                      '${widget.name}',
+                      'No ongoing challenges',
                       style: TextStyle(
                         color: Colors.white,
                         fontSize: 30
@@ -243,7 +252,7 @@ class _CardState extends State<ChallengeCard> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [ 
-                    Align(
+                    /*Align(
                       alignment: Alignment.bottomLeft,
                       child: Text(
                         'no info',
@@ -252,8 +261,8 @@ class _CardState extends State<ChallengeCard> {
                           fontSize: 20
                         ),
                       ),
-                    ),
-                    Align(
+                    ),*/
+                    /*Align(
                       alignment: Alignment.bottomRight,
                       child: Padding(
                         padding: EdgeInsets.only(right: 15),
@@ -264,7 +273,7 @@ class _CardState extends State<ChallengeCard> {
                           colorFilter: ColorFilter.mode(Colors.white, BlendMode.srcIn),
                         ),
                       )
-                    ),
+                    ),*/
                   ],
                 )
               ],

--- a/client/lib/widgets/challenge_cards.dart
+++ b/client/lib/widgets/challenge_cards.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
@@ -14,7 +12,7 @@ class ChallengeCard extends StatefulWidget{
   final String type;
   final String name;
   final Text description;
-  final bool timeLimit;
+  //final bool timeLimit;
   // 0 = not started, 1 = ongoing, 2 = done
   int status;
 
@@ -23,7 +21,7 @@ class ChallengeCard extends StatefulWidget{
     required this.name,
     required this.type,
     required this.description,
-    required this.timeLimit,
+    //required this.timeLimit,
     required this.status
   });
 
@@ -249,33 +247,6 @@ class _CardState extends State<ChallengeCard> {
                   ),
                 ),
                 Padding(padding: EdgeInsets.all(35)),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [ 
-                    /*Align(
-                      alignment: Alignment.bottomLeft,
-                      child: Text(
-                        'no info',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 20
-                        ),
-                      ),
-                    ),*/
-                    /*Align(
-                      alignment: Alignment.bottomRight,
-                      child: Padding(
-                        padding: EdgeInsets.only(right: 15),
-                        child: SvgPicture.asset(
-                          'assets/images/img_arrow_right.svg',
-                          height: 20,
-                          width: 20,
-                          colorFilter: ColorFilter.mode(Colors.white, BlendMode.srcIn),
-                        ),
-                      )
-                    ),*/
-                  ],
-                )
               ],
             )
           )


### PR DESCRIPTION
Added status as a field for the ChallengeCard class. You can now filter the challenge page based on both type and status and the ongoing challenges are now displayed on the start page. However, if no challenges are qualified for the active filters all challenges are shown. If I have time to spare onwards I might fix something that tells you that there are no challenges of that kind. Time limit is now a ignored type because it causes too much trouble, will most likely remove it.