### PR TITLE
build now works with .env

### DIFF
--- a/client/android/app/proguard-rules.pro
+++ b/client/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.example.trailquest.BuildConfig { *; }


### PR DESCRIPTION
 but if we change the package name from com.example.trailquest we need to update in proguard-rules.pro too.


This is a quick change to fix a small bug.